### PR TITLE
Update abilities component styling

### DIFF
--- a/.firebase/pokemon_data.json
+++ b/.firebase/pokemon_data.json
@@ -2649,6 +2649,20 @@
       61,
       79,
       42
+    ],
+    "items": [
+      null,
+      null
+    ],
+    "gender_ratio": [
+      0,
+      100
+    ],
+    "egg_cycles": 20,
+    "friendship": 50,
+    "growth_rate": "Medium Fast",
+    "egg_groups": [
+      "Fairy"
     ]
   },
   {
@@ -5578,6 +5592,17 @@
       60,
       100,
       60
+    ],
+    "items": [
+      null,
+      "Star Piece"
+    ],
+    "gender_ratio": [],
+    "egg_cycles": 25,
+    "friendship": 50,
+    "growth_rate": "Medium Slow",
+    "egg_groups": [
+      "Mineral"
     ]
   },
   {

--- a/.firebase/pokemon_data.json
+++ b/.firebase/pokemon_data.json
@@ -285,7 +285,7 @@
     ],
     "abilities": [
       "Ball Fetch",
-      "None",
+      null,
       "Rattled"
     ],
     "base_stats": [
@@ -324,7 +324,7 @@
     ],
     "abilities": [
       "Strong Jaw",
-      "None",
+      null,
       "Competitive"
     ],
     "base_stats": [

--- a/app/pokedex/details/pokedex-ability-details.tsx
+++ b/app/pokedex/details/pokedex-ability-details.tsx
@@ -1,0 +1,36 @@
+"use client";
+import "../../../styles/pokedex/pokedex-modal.css";
+
+export default function PokedexAbilityDetails({ abilities }: { abilities: string[] }) {
+    return (
+        <div className="flex items-center">
+            <h3 className="mr-1.5">Abilities:</h3>
+            {abilities
+                .map((ability, i) => {
+                    if (!ability) return null;
+                    return (
+                        <span key={ability}>
+                            {i === 1 && <span className="mx-1.5">/</span>}
+                            {i === 2 ? (
+                                <span className="ml-2.5">(Hidden: {GetAbilityAnchorTag(ability)})</span>
+                            ) : (
+                                GetAbilityAnchorTag(ability)
+                            )}
+                        </span>
+                    );
+                })}
+        </div>
+    );
+}
+
+function GetAbilityAnchorTag(ability: string) {
+    return (
+        <a
+            href={`https://bulbapedia.bulbagarden.net/wiki/${ability}_(Ability)`}
+            target="_blank"
+            className="pokedex-ability-details"
+        >
+            {ability}
+        </a>
+    )
+}

--- a/app/pokedex/details/pokedex-ability-details.tsx
+++ b/app/pokedex/details/pokedex-ability-details.tsx
@@ -7,7 +7,7 @@ export default function PokedexAbilityDetails({ abilities }: { abilities: string
             <h3 className="mr-1.5">Abilities:</h3>
             {abilities
                 .map((ability, i) => {
-                    if (!ability) return null;
+                    if (!ability) return null; // Some Pokemon do not have their second normal ability or hidden ability, so we skip those
                     return (
                         <span key={ability}>
                             {i === 1 && <span className="mx-1.5">/</span>}

--- a/app/pokedex/details/pokedex-type-details.tsx
+++ b/app/pokedex/details/pokedex-type-details.tsx
@@ -1,5 +1,5 @@
 "use client";
-import "../../../styles/pokedex/pokedex-type-details.css";
+import "../../../styles/pokedex/pokedex-modal.css";
 
 export default function PokedexTypeDetails({ types, typeColours }: { types: string[], typeColours: string[] }) {
     return (

--- a/app/pokedex/pokedex-modal.tsx
+++ b/app/pokedex/pokedex-modal.tsx
@@ -2,6 +2,7 @@
 import { Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from "@heroui/react";
 import { Pokemon } from "../../types/pokemon";
 import PokedexTypeDetails from "./details/pokedex-type-details";
+import PokedexAbilityDetails from "./details/pokedex-ability-details";
 
 export default function PokedexModal({ pokemon, isOpen, onCloseAction }: { pokemon: Pokemon, isOpen: boolean, onCloseAction: () => void }) {
     return (
@@ -11,9 +12,7 @@ export default function PokedexModal({ pokemon, isOpen, onCloseAction }: { pokem
                 <ModalBody>
                     <img src={pokemon.full_image} alt={pokemon.name} width={192} height={192}></img>
                     <PokedexTypeDetails types={pokemon.type} typeColours={pokemon.type_colours} />
-                    <p>{pokemon.abilities[0]}</p>
-                    <p>{pokemon.abilities[1]}</p>
-                    <p>Hidden: {pokemon.abilities[2]}</p>
+                    <PokedexAbilityDetails abilities={pokemon.abilities} />
                     <p>Base stats: {pokemon.base_stats}</p>
                     <p>Catch Rate: {pokemon.catch_rate}</p>
                     <p>Exp Yield: {pokemon.exp_yield}</p>

--- a/styles/pokedex/pokedex-modal.css
+++ b/styles/pokedex/pokedex-modal.css
@@ -7,3 +7,12 @@
     text-align: center;
     margin-left: 10px;
 }
+
+.pokedex-ability-details {
+    text-decoration: underline;
+    color: dodgerblue;
+    cursor: pointer;
+    }
+    .pokedex-ability-details:hover {
+        color: mediumslateblue;
+}


### PR DESCRIPTION
Adds a new component for ability styling. A pokemon can have any combination of:
- 2 normal abilities and 1 hidden (ex. Bibarel)
- 1 normal ability and 1 hidden (ex. Yamper)
- 1 normal ability and no hidden (ex. Poipole)

This also refactors the stylesheet used by types to be all encompassing for any modal styles, to reduce file bloat. It also fixes some bad data in the pokedex data.

**NOTE:** Some abilities will overflow to 2 lines; this'll be covered when the entire modal gets a UI overhaul