### PR TITLE
Add pokemon egg group details

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following free resources were used when developing this webpage:
 
 In pokedex modal:
 
+- EV Yield on defeat
 - Caught locations for pokemon (level range, day/night, grass/water)
 - Moves table (level, up, TM/HM, Tutor, Egg)
 - Evolution path with links in modal

--- a/app/pokedex/details/pokedex-egg-groups-details.tsx
+++ b/app/pokedex/details/pokedex-egg-groups-details.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+export default function PokedexEggGroupDetails({ eggGroups }: { eggGroups: string[] }) {
+    return (
+        <div className="flex items-center">
+            <h3 className="mr-1.5">Egg Groups:</h3>
+            {eggGroups.map((group, i) => {
+                return (
+                    <span key={group}>
+                        {i > 0 && <span className="mx-1.5"> and </span>}
+                        {group !== "Undiscovered" ? (
+                            <a
+                                href={`https://bulbapedia.bulbagarden.net/wiki/${group.replace(" ", "_")}_(Egg_Group)`}
+                                target="_blank"
+                                className="pokedex-url text-center"
+                                rel="noopener noreferrer"
+                            >
+                                {group}
+                            </a>
+                        ) : <span>{group}</span>
+                        }
+                    </span>
+                );
+            })}
+        </div>
+    );
+}

--- a/app/pokedex/details/pokedex-tiled-details.tsx
+++ b/app/pokedex/details/pokedex-tiled-details.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { Card, CardHeader, CardBody } from "@heroui/react";
+
+export default function PokedexTiledDetails({ label, value, url }: { label: string, value: string | number, url: string }) {
+    return (
+        <Card key={label} shadow="sm" className="w-30 h-24">
+            <CardHeader className="font-bold text-center flex flex-col items-center justify-center">{label}:</CardHeader>
+            <CardBody className="flex flex-col items-center justify-center">
+                <a href={url} target="_blank" className="pokedex-url text-center">{value}</a>
+            </CardBody>
+        </Card>
+    );
+}

--- a/app/pokedex/pokedex-modal.tsx
+++ b/app/pokedex/pokedex-modal.tsx
@@ -7,6 +7,8 @@ import PokedexAbilityDetails from "./details/pokedex-ability-details";
 import PokedexBaseStatsDetails from "./details/pokedex-base-stats-details";
 import PokedexItemDetails from "./details/pokedex-item-details";
 import PokedexGenderDetails from "./details/pokedex-gender-details";
+import PokedexTiledDetails from "./details/pokedex-tiled-details";
+import PokedexEggGroupDetails from "./details/pokedex-egg-groups-details";
 
 export default function PokedexModal({ pokemon, isOpen, onCloseAction }: { pokemon: Pokemon, isOpen: boolean, onCloseAction: () => void }) {
     return (
@@ -26,14 +28,14 @@ export default function PokedexModal({ pokemon, isOpen, onCloseAction }: { pokem
                     <PokedexAbilityDetails abilities={pokemon.abilities} />
                     <PokedexItemDetails items={pokemon.items} />
                     <PokedexGenderDetails genderRatios={pokemon.gender_ratio} />
+                    <PokedexEggGroupDetails eggGroups={pokemon.egg_groups} />
                     <PokedexBaseStatsDetails baseStats={pokemon.base_stats} />
-                    <p>Catch Rate: {pokemon.catch_rate}</p>
-                    <p>Exp Yield: {pokemon.exp_yield}</p>
-                    {/* TODO later: get icon(s) using url like: https://img.pokemondb.net/sprites/items/ability-capsule.png */}
-                    <p>Egg Groups: {pokemon.egg_groups}</p>
-                    <p>Egg Cycles: {pokemon.egg_cycles}</p>
-                    <p>Friendship: {pokemon.friendship}</p>
-                    <p>Growth Rate: {pokemon.growth_rate}</p>
+                    <div className="flex flex-wrap justify-center gap-4 mt-4">
+                        <PokedexTiledDetails label="Catch Rate" value={pokemon.catch_rate} url="https://bulbapedia.bulbagarden.net/wiki/Catch_rate" />
+                        <PokedexTiledDetails label="Exp. Yield" value={pokemon.exp_yield} url="https://bulbapedia.bulbagarden.net/wiki/Experience#Relation_to_level" />
+                        <PokedexTiledDetails label="Egg Cycles" value={pokemon.egg_cycles} url="https://bulbapedia.bulbagarden.net/wiki/Egg_cycle" />
+                        <PokedexTiledDetails label="Friendship" value={pokemon.friendship} url="https://bulbapedia.bulbagarden.net/wiki/Friendship" />
+                    </div>
                 </ModalBody>
                 <ModalFooter>Footer</ModalFooter>
             </ModalContent>


### PR DESCRIPTION
Add egg group details, as well as a common component for standalone info (presented in a card, with a link to bulbapedia due to most of the info being obtuse at first glance)